### PR TITLE
Switch to nuxeo-document

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,13 +22,9 @@
   "dependencies": {
     "polymer": "~1.2.1",
     "nuxeo-elements": "nuxeo/nuxeo-elements#~0.2.3",
-    "nuxeo-dataviz-elements": "nuxeo/nuxeo-dataviz-elements#~0.2.1",
-    "nuxeo-document-property": "jfletcher-nuxeo/nuxeo-document-property#~1.0.1"
+    "nuxeo-dataviz-elements": "nuxeo/nuxeo-dataviz-elements#~0.2.1"
   },
   "devDependencies": {
     "moment": "~2.10.6"
-  },
-  "resolutions": {
-    "nuxeo-elements": "fix-nuxeo-document"
   }
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -28,7 +28,7 @@ Contributors:
   <script src="../../moment/min/moment-with-locales.js"></script>
 
   <link rel="import" href="../../nuxeo-elements/nuxeo-connection.html">
-  <link rel="import" href="../../nuxeo-document-property/nuxeo-document-property.html">
+  <link rel="import" href="../../nuxeo-elements/nuxeo-document.html">
 
   <link rel="import" href="../nuxeo-audit-data.html">
 
@@ -80,7 +80,8 @@ Contributors:
       <template is="dom-repeat" items="[[downloads]]" as="downloadedDoc">
         <tr>
           <td>
-            <nuxeo-document-property doc-id="[[downloadedDoc.key]]" property-name="file:content" sub-property-name="name"></nuxeo-document-property>
+            <nuxeo-document auto doc-id="[[downloadedDoc.key]]" response="{{downloadedDoc.instance}}"></nuxeo-document>
+            <span>[[downloadedDoc.instance.properties.file:content.name]]</span>
           </td>
           <td>[[downloadedDoc.value]]</td>
         </tr>


### PR DESCRIPTION
Nelson pointed out that Polymer expressions work ok with the
schema:field syntax, so I can use nuxeo-document instead of
nuxeo-document-property.
